### PR TITLE
PR Prompt & AutoMerge Prompt

### DIFF
--- a/apps/web/app/ai-context/ConfigPage.tsx
+++ b/apps/web/app/ai-context/ConfigPage.tsx
@@ -9,26 +9,22 @@ import Link from 'next/link';
 export const ConfigPage = () => {
     const [projectContext, setProjectContext] = useState('');
     const [codingStandards, setCodingStandards] = useState('');
-    const [prPrompt, setPrPrompt] = useState('');
-    const [activeTab, setActiveTab] = useState<'project-context' | 'coding-standards' | 'pr-prompt'>('project-context');
+    const [activeTab, setActiveTab] = useState<'project-context' | 'coding-standards'>('project-context');
     const [loading, setLoading] = useState(true);
     const [saving, setSaving] = useState(false);
 
     const loadFiles = useCallback(async () => {
         try {
-            const [projectResponse, codingResponse, prPromptResponse] = await Promise.all([
+            const [projectResponse, codingResponse] = await Promise.all([
                 fetch('/api/preferences/project-context'),
-                fetch('/api/preferences/coding-standards'),
-                fetch('/api/preferences/pr-prompt')
+                fetch('/api/preferences/coding-standards')
             ]);
 
             const projectData = await projectResponse.text();
             const codingData = await codingResponse.text();
-            const prPromptData = await prPromptResponse.text();
 
             setProjectContext(projectData);
             setCodingStandards(codingData);
-            setPrPrompt(prPromptData);
         } catch (error) {
             console.error('Error loading files:', error);
             enqueueSnackbar('Error loading preference files', { variant: 'error' });
@@ -54,11 +50,6 @@ export const ConfigPage = () => {
                     method: 'POST',
                     headers: { 'Content-Type': 'text/plain' },
                     body: codingStandards
-                }),
-                fetch('/api/preferences/pr-prompt', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'text/plain' },
-                    body: prPrompt
                 })
             ]);
 
@@ -69,7 +60,7 @@ export const ConfigPage = () => {
         } finally {
             setSaving(false);
         }
-    }, [projectContext, codingStandards, prPrompt]);
+    }, [projectContext, codingStandards]);
 
     const handleProjectContextChange = useCallback((value: string | undefined) => {
         setProjectContext(value || '');
@@ -79,9 +70,6 @@ export const ConfigPage = () => {
         setCodingStandards(value || '');
     }, []);
 
-    const handlePrPromptChange = useCallback((value: string | undefined) => {
-        setPrPrompt(value || '');
-    }, []);
 
     const handleProjectTabClick = useCallback(() => {
         setActiveTab('project-context');
@@ -91,9 +79,6 @@ export const ConfigPage = () => {
         setActiveTab('coding-standards');
     }, []);
 
-    const handlePrPromptTabClick = useCallback(() => {
-        setActiveTab('pr-prompt');
-    }, []);
 
     const handleSaveClick = useCallback(() => {
         handleSave().catch(console.error);
@@ -164,18 +149,6 @@ export const ConfigPage = () => {
                                 <FileText className="w-4 h-4 inline-block mr-2" />
                                 Coding Standards
                             </button>
-                            <button
-                                type="button"
-                                onClick={handlePrPromptTabClick}
-                                className={`py-4 px-1 border-b-2 font-medium text-sm ${
-                                    activeTab === 'pr-prompt'
-                                        ? 'border-blue-500 text-blue-600 dark:text-blue-400'
-                                        : 'border-transparent text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300'
-                                }`}
-                            >
-                                <FileText className="w-4 h-4 inline-block mr-2" />
-                                PR Prompt
-                            </button>
                         </nav>
                     </div>
 
@@ -202,21 +175,6 @@ export const ConfigPage = () => {
                                 language="markdown"
                                 theme="vs-dark"
                                 onChange={handleCodingStandardsChange}
-                                options={{
-                                    fontSize: 14,
-                                    wordWrap: 'on',
-                                    minimap: { enabled: false },
-                                    scrollBeyondLastLine: false,
-                                    automaticLayout: true,
-                                }}
-                            />
-                        )}
-                        {activeTab === 'pr-prompt' && (
-                            <Editor
-                                value={prPrompt}
-                                language="markdown"
-                                theme="vs-dark"
-                                onChange={handlePrPromptChange}
                                 options={{
                                     fontSize: 14,
                                     wordWrap: 'on',

--- a/apps/web/app/api/preferences/automations/route.ts
+++ b/apps/web/app/api/preferences/automations/route.ts
@@ -11,9 +11,8 @@ const DEFAULT_AUTOMATIONS = {
     doCodeReviewBeforeFinishing: false,
     automaticTaskPicking: false,
     baseBranch: 'main',
-    autoMergePR: false,
-    autoMergeDecisionMode: 'claude-decision',
-    autoMergePrompt: ''
+    automaticallyMergePR: false,
+    mergeDecisionMode: 'claude-decision'
 };
 
 export async function GET() {
@@ -58,26 +57,21 @@ export async function POST(request: NextRequest) {
             }
 
             // Validate optional auto-merge fields if present
-            if (parsed.autoMergePR !== undefined && typeof parsed.autoMergePR !== 'boolean') {
-                return new NextResponse('autoMergePR must be a boolean', { status: 400 });
+            if (parsed.automaticallyMergePR !== undefined && typeof parsed.automaticallyMergePR !== 'boolean') {
+                return new NextResponse('automaticallyMergePR must be a boolean', { status: 400 });
             }
 
-            if (parsed.autoMergeDecisionMode !== undefined && 
-                (typeof parsed.autoMergeDecisionMode !== 'string' || 
-                !['always', 'claude-decision'].includes(parsed.autoMergeDecisionMode))) {
-                return new NextResponse('autoMergeDecisionMode must be either "always" or "claude-decision"', { status: 400 });
-            }
-
-            if (parsed.autoMergePrompt !== undefined && typeof parsed.autoMergePrompt !== 'string') {
-                return new NextResponse('autoMergePrompt must be a string', { status: 400 });
+            if (parsed.mergeDecisionMode !== undefined && 
+                (typeof parsed.mergeDecisionMode !== 'string' || 
+                !['always', 'claude-decision'].includes(parsed.mergeDecisionMode))) {
+                return new NextResponse('mergeDecisionMode must be either "always" or "claude-decision"', { status: 400 });
             }
 
             // Set defaults for missing auto-merge fields
             const validatedData = {
                 ...parsed,
-                autoMergePR: parsed.autoMergePR ?? DEFAULT_AUTOMATIONS.autoMergePR,
-                autoMergeDecisionMode: parsed.autoMergeDecisionMode ?? DEFAULT_AUTOMATIONS.autoMergeDecisionMode,
-                autoMergePrompt: parsed.autoMergePrompt ?? DEFAULT_AUTOMATIONS.autoMergePrompt
+                automaticallyMergePR: parsed.automaticallyMergePR ?? DEFAULT_AUTOMATIONS.automaticallyMergePR,
+                mergeDecisionMode: parsed.mergeDecisionMode ?? DEFAULT_AUTOMATIONS.mergeDecisionMode
             };
 
             // Set final content with validated data

--- a/apps/web/app/api/preferences/automerge-prompt/route.ts
+++ b/apps/web/app/api/preferences/automerge-prompt/route.ts
@@ -1,0 +1,91 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { existsSync } from 'node:fs';
+
+const PREFERENCES_DIR = '/workspace/data/preferences';
+const AUTOMERGE_PROMPT_FILE = join(PREFERENCES_DIR, 'automerge-prompt.md');
+
+const DEFAULT_AUTOMERGE_PROMPT = `Review this pull request and decide if it should be automatically merged.
+
+## Quick Assessment (Score 1-10):
+
+**1. Code Quality (40%)**
+- Clean, readable code
+- No obvious bugs or issues
+- Follows existing patterns
+
+**2. Safety & Risk (35%)**
+- No breaking changes
+- No security issues
+- Safe to deploy
+
+**3. Completeness (25%)**
+- Feature/fix is complete
+- No work-in-progress code
+- Addresses the requirements
+
+## Decision:
+
+**MERGE if total score ≥ 7/10**
+
+### If MERGING:
+\`\`\`
+SCORE: [X]/10
+DECISION: MERGE
+REASON: [brief why]
+
+gh pr merge {{PR_URL}} --squash --body "Auto-merged: [X]/10" --delete-branch
+\`\`\`
+
+### If NOT MERGING:
+\`\`\`
+SCORE: [X]/10
+DECISION: DO NOT MERGE
+REASON: [main issues]
+\`\`\`
+
+Be pragmatic - focus on shipping working code, not perfection.`;
+
+export async function GET() {
+    try {
+        // Ensure directory exists
+        if (!existsSync(PREFERENCES_DIR)) {
+            await mkdir(PREFERENCES_DIR, { recursive: true });
+        }
+
+        // Check if file exists, create with default content if not
+        if (!existsSync(AUTOMERGE_PROMPT_FILE)) {
+            await writeFile(AUTOMERGE_PROMPT_FILE, DEFAULT_AUTOMERGE_PROMPT);
+
+            return new NextResponse(DEFAULT_AUTOMERGE_PROMPT);
+        }
+
+        const content = await readFile(AUTOMERGE_PROMPT_FILE, 'utf8');
+
+        return new NextResponse(content);
+    } catch (error) {
+        console.error('Error reading automerge-prompt.md:', error);
+
+        return new NextResponse('Error loading automerge prompt', { status: 500 });
+    }
+}
+
+export async function POST(request: NextRequest) {
+    try {
+        const content = await request.text();
+
+        // Ensure directory exists
+        if (!existsSync(PREFERENCES_DIR)) {
+            await mkdir(PREFERENCES_DIR, { recursive: true });
+        }
+
+        await writeFile(AUTOMERGE_PROMPT_FILE, content);
+
+        return new NextResponse('Automerge prompt saved successfully');
+    } catch (error) {
+        console.error('Error saving automerge-prompt.md:', error);
+
+        return new NextResponse('Error saving automerge prompt', { status: 500 });
+    }
+}

--- a/apps/web/app/api/preferences/review-prompt/route.ts
+++ b/apps/web/app/api/preferences/review-prompt/route.ts
@@ -4,9 +4,9 @@ import { join } from 'node:path';
 import { existsSync } from 'node:fs';
 
 const PREFERENCES_DIR = '/workspace/data/preferences';
-const PR_PROMPT_FILE = join(PREFERENCES_DIR, 'pr-prompt.md');
+const REVIEW_PROMPT_FILE = join(PREFERENCES_DIR, 'review-prompt.md');
 
-const DEFAULT_PR_PROMPT = `Your goal is to code review the current project before a PR is being created.
+const DEFAULT_REVIEW_PROMPT = `Your goal is to code review the current project before a PR is being created.
 
 ## Analysis Requirements
 1. **Assess the codebase thoroughly**
@@ -36,19 +36,19 @@ export async function GET() {
         }
 
         // Check if file exists, create with default content if not
-        if (!existsSync(PR_PROMPT_FILE)) {
-            await writeFile(PR_PROMPT_FILE, DEFAULT_PR_PROMPT);
+        if (!existsSync(REVIEW_PROMPT_FILE)) {
+            await writeFile(REVIEW_PROMPT_FILE, DEFAULT_REVIEW_PROMPT);
 
-            return new NextResponse(DEFAULT_PR_PROMPT);
+            return new NextResponse(DEFAULT_REVIEW_PROMPT);
         }
 
-        const content = await readFile(PR_PROMPT_FILE, 'utf8');
+        const content = await readFile(REVIEW_PROMPT_FILE, 'utf8');
 
         return new NextResponse(content);
     } catch (error) {
-        console.error('Error reading pr-prompt.md:', error);
+        console.error('Error reading review-prompt.md:', error);
 
-        return new NextResponse('Error loading PR prompt', { status: 500 });
+        return new NextResponse('Error loading review prompt', { status: 500 });
     }
 }
 
@@ -61,12 +61,12 @@ export async function POST(request: NextRequest) {
             await mkdir(PREFERENCES_DIR, { recursive: true });
         }
 
-        await writeFile(PR_PROMPT_FILE, content);
+        await writeFile(REVIEW_PROMPT_FILE, content);
 
-        return new NextResponse('PR prompt saved successfully');
+        return new NextResponse('Review prompt saved successfully');
     } catch (error) {
-        console.error('Error saving pr-prompt.md:', error);
+        console.error('Error saving review-prompt.md:', error);
 
-        return new NextResponse('Error saving PR prompt', { status: 500 });
+        return new NextResponse('Error saving review prompt', { status: 500 });
     }
 }

--- a/apps/web/app/automations/components/AutomationSettings.tsx
+++ b/apps/web/app/automations/components/AutomationSettings.tsx
@@ -1,9 +1,8 @@
 'use client';
 
 import React from 'react';
-import { ToggleLeft, ToggleRight, CheckCircle2, GitPullRequest, Settings, GitBranch, GitMerge, Sparkles } from 'lucide-react';
+import { ToggleLeft, ToggleRight, CheckCircle2, GitPullRequest, Settings, GitBranch, GitMerge } from 'lucide-react';
 import type { BranchInfo, ProjectBranchesResponse } from '@vibe-remote/vibe-kanban-api/types/api';
-import { ClaudePromptEditor } from './ClaudePromptEditor';
 import { AutomationStatusSummary } from './AutomationStatusSummary';
 
 type AutomationSettings = {
@@ -13,41 +12,30 @@ type AutomationSettings = {
     baseBranch: string;
     automaticallyMergePR: boolean;
     mergeDecisionMode: 'always' | 'claude-decision';
-    claudeMergePrompt: string;
 };
 
 type AutomationSettingsProps = {
     readonly settings: AutomationSettings;
     readonly branchData: ProjectBranchesResponse | null;
     readonly branchesLoading: boolean;
-    readonly showPromptEditor: boolean;
-    readonly saving: boolean;
     readonly onAutoPRToggle: () => void;
     readonly onCodeReviewToggle: () => void;
     readonly onTaskPickingToggle: () => void;
     readonly onBranchSelectChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
     readonly onAutoMergeToggle: () => void;
     readonly onMergeDecisionModeChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
-    readonly onPromptEditorToggle: () => void;
-    readonly onClaudePromptChange: (value: string) => void;
-    readonly onSaveClick: () => void;
 };
 
 export const AutomationSettings: React.FC<AutomationSettingsProps> = ({
     settings,
     branchData,
     branchesLoading,
-    showPromptEditor,
-    saving,
     onAutoPRToggle,
     onCodeReviewToggle,
     onTaskPickingToggle,
     onBranchSelectChange,
     onAutoMergeToggle,
-    onMergeDecisionModeChange,
-    onPromptEditorToggle,
-    onClaudePromptChange,
-    onSaveClick
+    onMergeDecisionModeChange
 }) => {
     return (
         <div className="space-y-6">
@@ -134,28 +122,12 @@ export const AutomationSettings: React.FC<AutomationSettingsProps> = ({
                                 <option value="claude-decision">Claude Decision</option>
                             </select>
 
-                            {/* Claude Prompt Editor Toggle */}
+                            {/* Info message for Claude Decision mode */}
                             {settings.mergeDecisionMode === 'claude-decision' && (
                                 <div className="mt-3">
-                                    <button
-                                        type="button"
-                                        onClick={onPromptEditorToggle}
-                                        className="inline-flex items-center gap-2 text-sm text-purple-600 hover:text-purple-700 dark:text-purple-400 dark:hover:text-purple-300"
-                                    >
-                                        <Sparkles className="w-4 h-4" />
-                                        {showPromptEditor ? 'Hide' : 'Edit'} Claude Prompt
-                                    </button>
-
-                                    {/* Inline Prompt Editor */}
-                                    {showPromptEditor ? <div className="mt-4 p-4 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded-lg">
-                                        <ClaudePromptEditor
-                                            prompt={settings.claudeMergePrompt}
-                                            onPromptChange={onClaudePromptChange}
-                                            onSave={onSaveClick}
-                                            onBack={onPromptEditorToggle}
-                                            saving={saving}
-                                        />
-                                    </div> : null}
+                                    <p className="text-xs text-purple-600 dark:text-purple-400">
+                                        Claude will review and decide whether to merge the PR
+                                    </p>
                                 </div>
                             )}
                         </div>

--- a/apps/web/app/automations/components/AutomationStatusSummary.tsx
+++ b/apps/web/app/automations/components/AutomationStatusSummary.tsx
@@ -9,7 +9,6 @@ type AutomationSettings = {
     baseBranch: string;
     automaticallyMergePR: boolean;
     mergeDecisionMode: 'always' | 'claude-decision';
-    claudeMergePrompt: string;
 };
 
 type AutomationStatusSummaryProps = {

--- a/packages/claude-wrapper/src/claude-wrapper.ts
+++ b/packages/claude-wrapper/src/claude-wrapper.ts
@@ -9,7 +9,7 @@ import { readPreferenceFiles } from '@vibe-remote/shared-utils/readPreferenceFil
 import { createTempPromptFile } from '@vibe-remote/shared-utils/createTempPromptFile';
 import { prependContextToPrompt } from '@vibe-remote/shared-utils/prependContextToPrompt';
 import { readAutomationPreferences } from '@vibe-remote/shared-utils/readAutomationPreferences';
-import { readPreferenceFile } from '@vibe-remote/shared-utils/readPreferenceFile';
+import { readReviewPrompt } from '@vibe-remote/shared-utils/readReviewPrompt';
 import { runClaudeCommand } from '@vibe-remote/shared-utils/runClaudeCommand';
 
 
@@ -132,16 +132,10 @@ function runClaudeFlowInit(): Promise<void> {
 
 async function executeCodeReview(originalPrompt: string, additionalArgs: string[] = []): Promise<void> {
 
-    const prPromptTemplate = readPreferenceFile('pr-prompt.md');
-    if (!prPromptTemplate) {
-        console.error('⚠️ Code review enabled but pr-prompt.md not found, skipping code review');
-
-        return;
-    }
-
+    const reviewPromptTemplate = readReviewPrompt();
     console.log('🔍 Starting code review process...');
 
-    const codeReviewPrompt = `\n\nThe following task was executed:\n\n${originalPrompt}${prPromptTemplate}`;
+    const codeReviewPrompt = `\n\nThe following task was executed:\n\n${originalPrompt}${reviewPromptTemplate}`;
     const promptFile = createTempPromptFile('code-review');
     writeFileSync(promptFile, codeReviewPrompt);
     await runClaudeCommand({promptFile, additionalArgs});

--- a/packages/shared-utils/src/readAutomationPreferences.ts
+++ b/packages/shared-utils/src/readAutomationPreferences.ts
@@ -5,9 +5,8 @@ export type AutomationPreferences = {
     doCodeReviewBeforeFinishing: boolean;
     automaticTaskPicking: boolean;
     baseBranch: string;
-    autoMergePR?: boolean;
-    autoMergeDecisionMode?: 'always' | 'claude-decision';
-    autoMergePrompt?: string;
+    automaticallyMergePR?: boolean;
+    mergeDecisionMode?: 'always' | 'claude-decision';
 };
 
 export function readAutomationPreferences(): AutomationPreferences {
@@ -35,14 +34,11 @@ export function readAutomationPreferences(): AutomationPreferences {
             baseBranch: preferences.baseBranch ?? defaultPreferences.baseBranch
         };
 
-        if (preferences.autoMergePR !== undefined)
-            result.autoMergePR = preferences.autoMergePR;
+        if (preferences.automaticallyMergePR !== undefined)
+            result.automaticallyMergePR = preferences.automaticallyMergePR;
 
-        if (preferences.autoMergeDecisionMode !== undefined)
-            result.autoMergeDecisionMode = preferences.autoMergeDecisionMode;
-
-        if (preferences.autoMergePrompt !== undefined)
-            result.autoMergePrompt = preferences.autoMergePrompt;
+        if (preferences.mergeDecisionMode !== undefined)
+            result.mergeDecisionMode = preferences.mergeDecisionMode;
 
         return result;
     } catch (error) {

--- a/packages/shared-utils/src/readAutomergePrompt.ts
+++ b/packages/shared-utils/src/readAutomergePrompt.ts
@@ -1,0 +1,59 @@
+import { existsSync, readFileSync } from 'node:fs';
+
+const DEFAULT_AUTOMERGE_PROMPT = `Review this pull request and decide if it should be automatically merged.
+
+## Quick Assessment (Score 1-10):
+
+**1. Code Quality (40%)**
+- Clean, readable code
+- No obvious bugs or issues
+- Follows existing patterns
+
+**2. Safety & Risk (35%)**
+- No breaking changes
+- No security issues
+- Safe to deploy
+
+**3. Completeness (25%)**
+- Feature/fix is complete
+- No work-in-progress code
+- Addresses the requirements
+
+## Decision:
+
+**MERGE if total score ≥ 7/10**
+
+### If MERGING:
+\`\`\`
+SCORE: [X]/10
+DECISION: MERGE
+REASON: [brief why]
+
+gh pr merge {{PR_URL}} --squash --body "Auto-merged: [X]/10" --delete-branch
+\`\`\`
+
+### If NOT MERGING:
+\`\`\`
+SCORE: [X]/10
+DECISION: DO NOT MERGE
+REASON: [main issues]
+\`\`\`
+
+Be pragmatic - focus on shipping working code, not perfection.`;
+
+export function readAutomergePrompt(): string {
+    const promptPath = '/workspace/data/preferences/automerge-prompt.md';
+    
+    if (!existsSync(promptPath))
+        return DEFAULT_AUTOMERGE_PROMPT;
+    
+    try {
+        const content = readFileSync(promptPath, 'utf8');
+
+        return content || DEFAULT_AUTOMERGE_PROMPT;
+    } catch (error) {
+        console.warn(`Warning: Could not read automerge-prompt.md: ${String(error)}`);
+
+        return DEFAULT_AUTOMERGE_PROMPT;
+    }
+}

--- a/packages/shared-utils/src/readReviewPrompt.ts
+++ b/packages/shared-utils/src/readReviewPrompt.ts
@@ -1,0 +1,40 @@
+import { existsSync, readFileSync } from 'node:fs';
+
+const DEFAULT_REVIEW_PROMPT = `Your goal is to code review the current project before a PR is being created.
+
+## Analysis Requirements
+1. **Assess the codebase thoroughly**
+2. **Analyze everything file by file** 
+3. **Determine how well the task was executed**
+
+## Review Criteria
+- Code quality and adherence to standards
+- No over engineering
+- Everything in the task should be implemented
+
+## Action Items
+
+If the task was not executed well, you should:
+
+- **Fix any errors** you find necessary
+- **Improve code quality** where needed
+- **Add missing functionality** to complete the task
+- **Enhance error handling** and validation
+`;
+
+export function readReviewPrompt(): string {
+    const promptPath = '/workspace/data/preferences/review-prompt.md';
+    
+    if (!existsSync(promptPath))
+        return DEFAULT_REVIEW_PROMPT;
+    
+    try {
+        const content = readFileSync(promptPath, 'utf8');
+
+        return content || DEFAULT_REVIEW_PROMPT;
+    } catch (error) {
+        console.warn(`Warning: Could not read review-prompt.md: ${String(error)}`);
+
+        return DEFAULT_REVIEW_PROMPT;
+    }
+}

--- a/packages/vibe-kanban-cleanup/src/claude/runAutoMerge.ts
+++ b/packages/vibe-kanban-cleanup/src/claude/runAutoMerge.ts
@@ -4,7 +4,7 @@ import { getTask } from '@vibe-remote/vibe-kanban-api/api/tasks/getTask';
 import { createTempPromptFile } from '@vibe-remote/shared-utils/createTempPromptFile';
 import { prependContextToPrompt } from '@vibe-remote/shared-utils/prependContextToPrompt';
 import { processTemplate } from '@vibe-remote/shared-utils/processTemplate';
-import { readAutomationPreferences } from '@vibe-remote/shared-utils/readAutomationPreferences';
+import { readAutomergePrompt } from '@vibe-remote/shared-utils/readAutomergePrompt';
 import { readPreferenceFiles } from '@vibe-remote/shared-utils/readPreferenceFiles';
 import { runClaudeCommand } from '@vibe-remote/shared-utils/runClaudeCommand';
 /**
@@ -24,13 +24,9 @@ export async function runAutoMerge(attemptId: string): Promise<void> {
         if (!task?.title || !task?.description)
             throw new Error(`Task not found for ID: ${taskAttempt.task_id}`);
 
-        const preferences = readAutomationPreferences();
-
         // Get project context
         const preferenceContext = readPreferenceFiles();
-        const promptTemplate = preferences.autoMergePrompt;
-        if (!promptTemplate)
-            throw new Error(`Auto-merge prompt template not found`);
+        const promptTemplate = readAutomergePrompt();
 
         // Process template with context
         const processedPrompt = processTemplate(promptTemplate, {

--- a/packages/vibe-kanban-cleanup/src/vibe-kanban-cleanup.ts
+++ b/packages/vibe-kanban-cleanup/src/vibe-kanban-cleanup.ts
@@ -29,7 +29,7 @@ class VibeKanbanCleanup {
                 console.log(`\n✅ PR created: ${prUrl}`);
 
                 // Handle auto-merge based on preferences
-                if (preferences.autoMergePR)
+                if (preferences.automaticallyMergePR)
                     await this.handleAutoMerge(preferences, prUrl, context);
 
             } else {
@@ -47,7 +47,7 @@ class VibeKanbanCleanup {
 
         console.log(`\n🔗 PR URL for merge: ${prUrl}`);
 
-        if (preferences.autoMergeDecisionMode === 'always') {
+        if (preferences.mergeDecisionMode === 'always') {
             console.log('\n🔀 Auto-merge mode is "always" - attempting to merge PR...');
 
             try {
@@ -59,7 +59,7 @@ class VibeKanbanCleanup {
             return;
         }
 
-        if (preferences.autoMergeDecisionMode === 'claude-decision') {
+        if (preferences.mergeDecisionMode === 'claude-decision') {
             console.log('\n🤖 Auto-merge mode is "claude-decision" - running Claude evaluation...');
             console.log(`📋 Task context: "${context.task.title}"`);
             console.log(`🔍 Attempt ID: ${context.containerInfo.attempt_id}`);


### PR DESCRIPTION
These changes apply to @apps/web


We currently have a PR prompt, that can be modified via the AI Context in the UI. And the other prompt is the AutoMerge in the apps/web/app/automations/AutomationsPage.tsx

The following changes need to be done:

*PR Prompt*
This is actually the 'review' prompt that is only used when automatic code review is enabled. So I want to move that to the apps/web/app/automations/AutomationsPage.tsx as well. Just like the automerge prompt.

*Storage*
Both prompt files should be stored in the /workspace/data/preference folders as MD files. Currently the automerge is embedded inside the JSON that is not correct.

*IMPORTANT*
Change the automerge prompt will also effect the packages/vibe-kanban-cleanup/src/vibe-kanban-cleanup.ts. Because I think that that is referencing the JSON rather than the separate MD file. 
