### PR TITLE
Vertical scaling prompt input

### DIFF
--- a/apps/web/app/automations/AutomationsPage.tsx
+++ b/apps/web/app/automations/AutomationsPage.tsx
@@ -335,7 +335,16 @@ export const AutomationsPage = () => {
                                 </div>
                                 
                                 {/* Editor */}
-                                <div className="h-[500px] mt-4">
+                                <div 
+                                    className="mt-4 border border-gray-300 dark:border-gray-600 rounded overflow-hidden"
+                                    style={{
+                                        height: '500px',
+                                        minHeight: '200px',
+                                        maxHeight: '800px',
+                                        resize: 'vertical',
+                                        overflow: 'auto'
+                                    }}
+                                >
                                     {activePromptTab === 'review' && (
                                         <Editor
                                             value={reviewPrompt}

--- a/apps/web/app/automations/components/JsonEditor.tsx
+++ b/apps/web/app/automations/components/JsonEditor.tsx
@@ -26,7 +26,16 @@ export const JsonEditor: React.FC<JsonEditorProps> = ({
                     </p>
                 </div>
             )}
-            <div className="h-[400px] border rounded-lg overflow-hidden">
+            <div 
+                className="border border-gray-300 dark:border-gray-600 rounded-lg overflow-hidden"
+                style={{
+                    height: '400px',
+                    minHeight: '200px',
+                    maxHeight: '800px',
+                    resize: 'vertical',
+                    overflow: 'auto'
+                }}
+            >
                 <Editor
                     value={jsonValue}
                     language="json"


### PR DESCRIPTION
In the apps/web/app/automations/AutomationsPage.tsx there is an inline editor for prompts in some cases. These editors should be resizable, ideally only vertical not horizontal.

#IMPORTANT
Only do this if it is supported via the MonacoEditor. Don't do it if you need to code custom stuff to make it work. I am fairly certain that the Monaco Editor should support it. So only use that option