### PR TITLE
Vertical scaling prompt input

### DIFF
--- a/apps/web/app/automations/components/AutomationSettings.tsx
+++ b/apps/web/app/automations/components/AutomationSettings.tsx
@@ -141,7 +141,7 @@ export const AutomationSettings: React.FC<AutomationSettingsProps> = ({
                                         <div className="bg-gray-100 dark:bg-gray-800 px-3 py-2 border-b border-gray-300 dark:border-gray-600">
                                             <span className="text-sm font-medium text-gray-700 dark:text-gray-300">Auto-merge Prompt</span>
                                         </div>
-                                        <div className="h-[200px]">
+                                        <div className="h-[200px] min-h-[100px] max-h-[600px] resize-y overflow-auto">
                                             <Editor
                                                 value={automergePrompt}
                                                 language="markdown"
@@ -201,7 +201,7 @@ export const AutomationSettings: React.FC<AutomationSettingsProps> = ({
                         <div className="bg-gray-100 dark:bg-gray-800 px-3 py-2 border-b border-gray-300 dark:border-gray-600">
                             <span className="text-sm font-medium text-gray-700 dark:text-gray-300">Review Prompt</span>
                         </div>
-                        <div className="h-[200px]">
+                        <div className="h-[200px] min-h-[100px] max-h-[600px] resize-y overflow-auto">
                             <Editor
                                 value={reviewPrompt}
                                 language="markdown"

--- a/apps/web/app/automations/components/JsonEditor.tsx
+++ b/apps/web/app/automations/components/JsonEditor.tsx
@@ -26,7 +26,7 @@ export const JsonEditor: React.FC<JsonEditorProps> = ({
                     </p>
                 </div>
             )}
-            <div className="h-[400px] border rounded-lg overflow-hidden">
+            <div className="h-[400px] min-h-[200px] max-h-[800px] resize-y overflow-auto border rounded-lg">
                 <Editor
                     value={jsonValue}
                     language="json"


### PR DESCRIPTION
In the apps/web/app/automations/AutomationsPage.tsx there is an inline editor for prompts in some cases. These editors should be resizable, ideally only vertical not horizontal.

#IMPORTANT
Only do this if it is supported via the MonacoEditor. Don't do it if you need to code custom stuff to make it work. I am fairly certain that the Monaco Editor should support it. So only use that option