### PR TITLE
Change Tasks Stats on Merge

### DIFF
--- a/packages/shared-utils/src/readAutomergePrompt.ts
+++ b/packages/shared-utils/src/readAutomergePrompt.ts
@@ -30,6 +30,7 @@ DECISION: MERGE
 REASON: [brief why]
 
 gh pr merge --merge --body "Auto-merged: [X]/10" --delete-branch
+vibe-kanban-sync-status
 \`\`\`
 
 ### If NOT MERGING:

--- a/packages/vibe-kanban-cleanup/package.json
+++ b/packages/vibe-kanban-cleanup/package.json
@@ -10,7 +10,8 @@
     }
   },
   "bin": {
-    "vibe-kanban-cleanup": "./dist/vibe-kanban-cleanup.mjs"
+    "vibe-kanban-cleanup": "./dist/vibe-kanban-cleanup.mjs",
+    "vibe-kanban-sync-status": "./dist/vibe-kanban-sync-status.mjs"
   },
   "files": [
     "dist"

--- a/packages/vibe-kanban-cleanup/src/functions/syncTaskStatusWithMerge.ts
+++ b/packages/vibe-kanban-cleanup/src/functions/syncTaskStatusWithMerge.ts
@@ -1,0 +1,65 @@
+import { execSync } from 'node:child_process';
+import { updateTask } from '@vibe-remote/vibe-kanban-api/api/tasks/updateTask';
+import { getTask } from '@vibe-remote/vibe-kanban-api/api/tasks/getTask';
+import { getTaskAttempt } from '@vibe-remote/vibe-kanban-api/api/task-attempts/getTaskAttempt';
+
+export async function syncTaskStatusWithMerge(attemptId: string): Promise<boolean> {
+    try {
+        // Get task attempt to find the task ID
+        const taskAttempt = await getTaskAttempt(attemptId);
+        
+        if (!taskAttempt) {
+            console.log(`⚠️ Task attempt not found for ID: ${attemptId}`);
+
+            return false;
+        }
+
+        // Get current task to check its status
+        const task = await getTask(taskAttempt.task_id);
+        
+        if (!task) {
+            console.log(`⚠️ Task not found for ID: ${taskAttempt.task_id}`);
+
+            return false;
+        }
+
+        // Skip if task is already done or cancelled
+        if (task.status === 'done' || task.status === 'cancelled') {
+            return false;
+        }
+
+        // Check if there's a merged PR for this branch
+        const branchName = taskAttempt.branch || execSync('git branch --show-current', { encoding: 'utf8' }).trim();
+        
+        try {
+            // Use --state all to include merged PRs
+            const prListJson = execSync(
+                `gh pr list --head ${branchName} --json state,mergedAt --state all --limit 1`,
+                { encoding: 'utf8' }
+            );
+            
+            const prs = JSON.parse(prListJson || '[]');
+            
+            if (prs.length > 0 && (prs[0].state === 'MERGED' || prs[0].mergedAt)) {
+                // PR is merged, update task status to done
+                await updateTask(taskAttempt.task_id, { status: 'done' });
+                console.log(`✅ Task "${task.title}" status updated to "done" (PR was merged)`);
+                
+                return true;
+            } else if (prs.length > 0) {
+                console.log(`ℹ️ PR state is "${prs[0].state}" - no status update needed`);
+            } else {
+                console.log(`ℹ️ No PR found for branch "${branchName}"`);
+            }
+        } catch (error) {
+            // GitHub CLI might not be available or configured
+            console.log(`⚠️ Could not check PR status: ${String(error)}`);
+        }
+        
+        return false;
+    } catch (error) {
+        console.log(`❌ Failed to sync task status: ${String(error)}`);
+        
+        return false;
+    }
+}

--- a/packages/vibe-kanban-cleanup/src/vibe-kanban-sync-status.ts
+++ b/packages/vibe-kanban-cleanup/src/vibe-kanban-sync-status.ts
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+
+import { fetchVibeKanbanContext } from "@vibe-remote/vibe-kanban-api/utils/fetchVibeKanbanContext";
+import { syncTaskStatusWithMerge } from "./functions/syncTaskStatusWithMerge";
+
+async function main(): Promise<void> {
+    try {
+        console.log('🔄 Syncing task status with merge state...');
+
+        if (!process.cwd().includes('/worktrees/')) {
+            throw new Error('Must be run from a vibe-kanban worktree directory');
+        }
+
+        const context = await fetchVibeKanbanContext();
+        console.log(`📋 Task: "${context.task.title}"`);
+        console.log(`🔍 Current status: ${context.task.status}`);
+
+        const wasUpdated = await syncTaskStatusWithMerge(context.containerInfo.attempt_id);
+        
+        if (wasUpdated) {
+            console.log('✅ Task status synchronized successfully');
+        } else {
+            console.log('ℹ️ No status update needed');
+        }
+
+    } catch (error) {
+        console.log('❌ Sync failed:', error);
+        process.exit(1);
+    }
+}
+
+// Execute
+await main();

--- a/packages/vibe-kanban-cleanup/tsup.config.ts
+++ b/packages/vibe-kanban-cleanup/tsup.config.ts
@@ -3,7 +3,8 @@ import { defineConfig } from 'tsup';
 export default defineConfig({
   // Entry points - the main CLI executables
   entry: {
-    'vibe-kanban-cleanup': 'src/vibe-kanban-cleanup.ts'
+    'vibe-kanban-cleanup': 'src/vibe-kanban-cleanup.ts',
+    'vibe-kanban-sync-status': 'src/vibe-kanban-sync-status.ts'
   },
   
   // Output single bundled files (not split)


### PR DESCRIPTION
When a task is automatically merged it should also update the tasks status to completed. Currently it stays "in review" because there is no way to detect if it was merged.\n\nUpdating the the task status is something that should happen via the vibe-kanban-api. 