### PR TITLE
Change Tasks Stats on Merge

### DIFF
--- a/packages/shared-utils/src/processTemplate.ts
+++ b/packages/shared-utils/src/processTemplate.ts
@@ -1,4 +1,6 @@
 type ProcessTemplateContext = {
+    taskId?: string;
+    projectId?: string;
     taskTitle?: string;
     taskDescription?: string;
 };
@@ -7,6 +9,14 @@ export function processTemplate(template: string, context: ProcessTemplateContex
     let processed = template;
 
     // Replace template variables - handle both formats (camelCase and UPPER_CASE)
+    processed = processed.replace(/{{taskId}}/g, context.taskId || '');
+    processed = processed.replace(/{{projectId}}/g, context.projectId || '');
+    processed = processed.replace(/{{taskTitle}}/g, context.taskTitle || '');
+    processed = processed.replace(/{{taskDescription}}/g, context.taskDescription || '');
+    
+    // Also support UPPER_CASE format for backward compatibility
+    processed = processed.replace(/{{TASK_ID}}/g, context.taskId || '');
+    processed = processed.replace(/{{PROJECT_ID}}/g, context.projectId || '');
     processed = processed.replace(/{{TASK_TITLE}}/g, context.taskTitle || '');
     processed = processed.replace(/{{TASK_DESCRIPTION}}/g, context.taskDescription || '');
 

--- a/packages/shared-utils/src/readAutomergePrompt.ts
+++ b/packages/shared-utils/src/readAutomergePrompt.ts
@@ -2,6 +2,10 @@ import { existsSync, readFileSync } from 'node:fs';
 
 const DEFAULT_AUTOMERGE_PROMPT = `Review this pull request and decide if it should be automatically merged.
 
+Task ID: {{taskId}}
+Project ID: {{projectId}}
+Task Title: {{taskTitle}}
+
 ## Quick Assessment (Score 1-10):
 
 **1. Code Quality (40%)**
@@ -30,7 +34,9 @@ DECISION: MERGE
 REASON: [brief why]
 
 gh pr merge --merge --body "Auto-merged: [X]/10" --delete-branch
-vibe-kanban-sync-status
+
+# Update task status to done using vibe-kanban MCP
+# Use the mcp__vibe_kanban__update_task tool with project_id: "{{projectId}}" and task_id: "{{taskId}}" to set status to 'done'
 \`\`\`
 
 ### If NOT MERGING:

--- a/packages/vibe-kanban-cleanup/src/claude/runAutoMerge.ts
+++ b/packages/vibe-kanban-cleanup/src/claude/runAutoMerge.ts
@@ -30,6 +30,8 @@ export async function runAutoMerge(attemptId: string): Promise<void> {
 
         // Process template with context
         const processedPrompt = processTemplate(promptTemplate, {
+            taskId: task.id,
+            projectId: task.project_id,
             taskTitle: task.title,
             taskDescription: task.description,
         });


### PR DESCRIPTION
When a task is automatically merged it should also update the tasks status to completed. Currently it stays "in review" because there is no way to detect if it was merged.\n\nUpdating the the task status is something that should happen via the vibe-kanban-api. 