### PR TITLE
Introducing [AI/HUMAN] tasks

### DIFF
--- a/packages/claude-wrapper/templates/claude-plan-prompt.md
+++ b/packages/claude-wrapper/templates/claude-plan-prompt.md
@@ -9,8 +9,8 @@ WORKFLOW CONTEXT:
 TASK CREATION REQUIREMENTS:
 
 MANDATORY FIELDS for each task:
-- **Title**: Clear, actionable task name. Prefixed with [AI] or [HUMAN]
-- **Type**: [AI] or [HUMAN] - determines who can execute this task
+- **Title**: Clear, actionable task name. Prefixed with [AI], [HUMAN], or [AI/HUMAN]
+- **Type**: [AI], [HUMAN], or [AI/HUMAN] - determines who can execute this task
 - **Priority**: HIGH/MEDIUM/LOW - helps taskpicker determine urgency
 - **Dependencies**: List any prerequisite tasks by their titles
 - **Acceptance Criteria**: 2-3 specific, measurable outcomes that define "done"
@@ -22,7 +22,35 @@ TASK DESIGN PRINCIPLES:
 - Tasks should have clear, measurable outcomes
 - [AI] tasks should be specific enough for autonomous completion but can be substantial (days/weeks of work)
 - [HUMAN] tasks should clearly define what human judgment/creativity is needed
+- [AI/HUMAN] tasks should be used when AI can perform the work BUT needs specific human input/clarification first
 - Dependencies should create a logical execution sequence
+
+CRITICAL TASK ANALYSIS - [AI/HUMAN] TASKS:
+Before labeling any task as [AI], you MUST:
+1. **Analyze the codebase** to find answers and understand existing patterns
+2. **Critically evaluate** if you have ALL information needed to deliver the task successfully
+3. **If information is missing AND cannot be found in the codebase**:
+   - Label the task as [AI/HUMAN] instead of [AI]
+   - Add a section "# HUMAN INPUT NEEDED" to the task description
+   - List specific questions that need human answers to successfully deliver the task
+   - Focus questions on clarifications about requirements, preferences, or external dependencies
+
+Example [AI/HUMAN] task format:
+```
+Title: [AI/HUMAN] Implement user authentication system
+Description: Set up authentication for the application
+
+# HUMAN INPUT NEEDED
+- Which authentication provider should be used? (Auth0, Firebase, custom JWT, etc.)
+- Should we support social logins? If yes, which providers (Google, GitHub, etc.)?
+- What user data should be stored in the session?
+- Are there specific security requirements or compliance standards to follow?
+
+Acceptance Criteria:
+- Authentication system is implemented based on human specifications
+- Users can log in and log out successfully
+- Session management is properly configured
+```
 
 WHEN TO SPLIT TASKS:
 ✅ Different skill sets required (backend vs frontend vs design)

--- a/packages/vibe-kanban-taskpicker/README.md
+++ b/packages/vibe-kanban-taskpicker/README.md
@@ -72,7 +72,8 @@ Evaluates TODO tasks based on:
 
 - **Task Prefixes**
   - `[AI]` - Tasks suitable for AI/automated implementation (highest priority)
-  - `[HUMAN]` - Tasks requiring human intervention (lower priority)
+  - `[AI/HUMAN]` - Tasks that AI can execute AFTER human provides required input (medium priority)
+  - `[HUMAN]` - Tasks requiring human intervention (skipped by taskpicker)
   
 - **Dependencies**
   - Tasks that block other work are prioritized
@@ -86,7 +87,14 @@ Evaluates TODO tasks based on:
   - Considers current work distribution
   - Avoids overloading any phase
 
-### 4. Task Selection & Update
+### 4. AI/HUMAN Task Handling
+For `[AI/HUMAN]` tasks:
+- The taskpicker checks if the "# HUMAN INPUT NEEDED" section has been answered
+- If human input is pending, the task is skipped
+- If human has provided responses (marked with "HUMAN RESPONSE:" or "ANSWERED:"), the task becomes eligible for AI execution
+- This allows AI to work on complex tasks that need human clarification without blocking on simple questions
+
+### 5. Task Selection & Update
 - Selects the optimal task based on analysis
 - Updates task status to "inprogress" using `mcp__vibe_kanban__update_task`
 - Provides clear reasoning for the selection

--- a/packages/vibe-kanban-taskpicker/templates/task-picker-prompt.md
+++ b/packages/vibe-kanban-taskpicker/templates/task-picker-prompt.md
@@ -20,7 +20,10 @@ The following tasks have been fetched from the Vibe Kanban API.
 ### Selection Criteria:
 
 1. **Task Status**: Only consider tasks with status "todo"
-2. **Task Type**: Prefer [AI] tasks over [HUMAN] tasks for automated execution
+2. **Task Type**: 
+   - **[AI]** tasks: Can be executed autonomously - PREFERRED
+   - **[HUMAN]** tasks: Require human execution - SKIP these
+   - **[AI/HUMAN]** tasks: Can be executed by AI ONLY IF "# HUMAN INPUT NEEDED" section has been answered
 3. **Dependencies**: Avoid tasks that are blocked by incomplete dependencies
 4. **Priority**: Consider priority markers (Priority: high/medium/low)
 5. **Effort**: Balance impact vs effort (Estimated effort: small/medium/large)
@@ -30,9 +33,13 @@ The following tasks have been fetched from the Vibe Kanban API.
 ### Analysis Approach:
 
 1. **Parse Task Details**: Look for priority, effort, type, and dependency markers in descriptions
-2. **Check Dependencies**: Ensure any mentioned dependencies are completed
-3. **Evaluate Impact**: Consider which task would provide the most value
-4. **Make Strategic Choice**: Select the task that best balances priority, effort, and project needs
+2. **Check Task Type**:
+   - For [AI/HUMAN] tasks: Check if "# HUMAN INPUT NEEDED" section exists and has been answered
+   - If questions remain unanswered, SKIP the task
+   - Look for text like "HUMAN RESPONSE:" or "ANSWERED:" indicating human input was provided
+3. **Check Dependencies**: Ensure any mentioned dependencies are completed
+4. **Evaluate Impact**: Consider which task would provide the most value
+5. **Make Strategic Choice**: Select the task that best balances priority, effort, and project needs
 
 ### Action to Take
 
@@ -65,9 +72,10 @@ TASK SELECTION DECISION
 ## Selected Task:
 - **Task ID:** [task-id]
 - **Title:** [task-title]
-- **Type:** [AI/HUMAN/UNKNOWN from description]
+- **Type:** [AI/HUMAN/AI-HUMAN from description]
 - **Priority:** [HIGH/MEDIUM/LOW from description or null]
 - **Estimated Effort:** [Small/Medium/Large from description or null]
+- **Human Input Status:** [For AI/HUMAN tasks: "Answered" or "Pending"]
 
 ## Selection Reasoning:
 [Explain why this task was selected over others - consider priority, effort, dependencies, type]
@@ -82,7 +90,8 @@ TASK SELECTION DECISION
 - 📋 The task data includes ALL available project tasks for context
 - 🎯 Make an intelligent choice based on the selection criteria above
 - ⚡ Only select tasks with status "todo" that are not blocked by dependencies
-- 🤖 Prefer [AI] tasks over [HUMAN] tasks for automated execution
-- 🔍 Look for markers in task descriptions: "Priority:", "Estimated effort:", "Type: [AI]", "Dependencies:"
+- 🤖 Task type priority: [AI] > [AI/HUMAN with answered questions] > Skip [HUMAN] and [AI/HUMAN with pending questions]
+- 🔍 Look for markers in task descriptions: "Priority:", "Estimated effort:", "Type: [AI]", "Type: [AI/HUMAN]", "Dependencies:"
+- 📝 For [AI/HUMAN] tasks: Check if "# HUMAN INPUT NEEDED" section has responses before selecting
 
 **Begin by analyzing the available tasks and making your intelligent selection.**


### PR DESCRIPTION
There is the option to PLAN during the packages/claude-wrapper/src/claude-wrapper.ts process. That contains a default prompt template packages/claude-wrapper/templates/claude-plan-prompt.md\n\nAnd later the result of that promt is used in the packages/vibe-kanban-taskpicker/src/claude/runTaskPicker.ts.\n\nI want to introduce the idea of [AI/HUMAN] tasks. These tasks are created during the planning phase. These are Tasks where Claude has determined that it needs more information from the human to succesfully perform that task.\n\nDuring the planning phase Claude is asked to look at a task, at the code base and all the context. And than create new tasks that can later be handled by the AI. This is all described in the packages/claude-wrapper/templates/claude-plan-prompt.md\n\n\nNow the idea: In that Prompt Claude should be challanged to critically look at each created task and determine if it has enough data to deliver it. When there is not enough data it should first analyse the code base to find answers.\n\nIf it is not confident enough that te task will result in the needed outcome it should do the following:\n- Label a task as [AI/HUMAN]\n- Create a section called # HUMAN INPUT NEEDED. In that section it would list all the questions that it has for the human. These are questions to further clarify parts that are needed to succesfully deliver the task.\n\nDuring the packages/vibe-kanban-taskpicker/src/claude/runTaskPicker.ts this concept should be taken into account. So you would have:\n- [HUMAN] tasks. These should not be handled by AI\n- [AI] tasks. These should be handled by AI\n- [AI/HUMAN] tasks. These should ONLY be handled by AI IF the human has provided the input needed in the task.\n\nCan you analyse the code base and find how we can implement this. The feeling I have is that this is mostly modification of prompts rather than actually writing code.\n 